### PR TITLE
Updated for Rust 20150109

### DIFF
--- a/examples/printing.rs
+++ b/examples/printing.rs
@@ -1,3 +1,4 @@
+#![allow(unstable)]
 extern crate email;
 
 use email::{MimeMessage, Header, Address};

--- a/src/address.rs
+++ b/src/address.rs
@@ -6,7 +6,7 @@ use super::header::{FromHeader, ToFoldedHeader};
 
 
 /// Represents an RFC 5322 Address
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Show)]
 #[stable]
 pub enum Address {
     /// A "regular" email address
@@ -35,7 +35,7 @@ impl Address {
     }
 }
 
-impl fmt::Show for Address {
+impl fmt::String for Address {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Address::Mailbox(ref mbox) => mbox.fmt(fmt),
@@ -55,7 +55,7 @@ impl fmt::Show for Address {
 }
 
 /// Represents an RFC 5322 mailbox
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Show)]
 #[stable]
 pub struct Mailbox {
     /// The given name for this address
@@ -84,7 +84,7 @@ impl Mailbox {
     }
 }
 
-impl fmt::Show for Mailbox {
+impl fmt::String for Mailbox {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self.name {
             Some(ref name) => write!(fmt, "\"{}\" <{}>", name, self.address),
@@ -106,7 +106,7 @@ impl FromHeader for Vec<Address> {
 }
 
 impl ToFoldedHeader for Vec<Address> {
-    fn to_folded_header(start_pos: uint, value: Vec<Address>) -> Option<String> {
+    fn to_folded_header(start_pos: usize, value: Vec<Address>) -> Option<String> {
         let mut header = String::new();
 
         let mut line_len = start_pos;

--- a/src/header.rs
+++ b/src/header.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 use chrono::{
     DateTime,
     FixedOffset,
-    Offset,
     UTC,
 };
 
@@ -44,11 +43,11 @@ pub trait ToHeader {
 /// in to a line.
 #[unstable]
 pub trait ToFoldedHeader {
-    fn to_folded_header(start_pos: uint, value: Self) -> Option<String>;
+    fn to_folded_header(start_pos: usize, value: Self) -> Option<String>;
 }
 
 impl<T: ToHeader> ToFoldedHeader for T {
-    fn to_folded_header(_: uint, value: T) -> Option<String> {
+    fn to_folded_header(_: usize, value: T) -> Option<String> {
         // We ignore the start_position because the thing will fold anyway.
         ToHeader::to_header(value)
     }
@@ -58,14 +57,14 @@ impl FromHeader for String {
     fn from_header(value: String) -> Option<String> {
         #[derive(Show,Copy)]
         enum ParseState {
-            Normal(uint),
-            SeenEquals(uint),
-            SeenQuestion(uint, uint),
+            Normal(usize),
+            SeenEquals(usize),
+            SeenQuestion(usize, usize),
         }
 
-        let mut state = ParseState::Normal(0u);
+        let mut state = ParseState::Normal(0);
         let mut decoded = String::new();
-        let mut pos = 0u;
+        let mut pos = 0;
 
         let value_slice = value.as_slice();
 
@@ -193,7 +192,7 @@ impl Header {
     }
 }
 
-impl fmt::Show for Header {
+impl fmt::String for Header {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{}: {}", self.name, self.value)
     }
@@ -256,7 +255,7 @@ impl HeaderMap {
         let rc = Rc::new(header);
         // Add to the ordered list of headers
         self.ordered_headers.push(rc.clone());
-        
+
         // and to the mapping between header names and values.
         match self.headers.entry(header_name) {
             Entry::Occupied(mut entry) => {
@@ -267,7 +266,7 @@ impl HeaderMap {
                 // as of yet, so make a new list and push it in.
                 let mut header_list = Vec::new();
                 header_list.push(rc.clone());
-                entry.set(header_list);
+                entry.insert(header_list);
             },
         };
     }
@@ -296,7 +295,7 @@ impl HeaderMap {
 
     #[unstable]
     /// Get the number of headers within this map.
-    pub fn len(&self) -> uint {
+    pub fn len(&self) -> usize {
         self.ordered_headers.len()
     }
 
@@ -428,7 +427,7 @@ mod tests {
             expected_headers.insert(header);
         }
 
-        let mut count = 0u;
+        let mut count = 0;
         // Ensure all the headers returned are expected
         for header in headers.iter() {
             assert!(expected_headers.contains(header));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,11 @@
-#![feature(phase)]
-#![feature(macro_rules)]
-#![feature(globs)]
-#![feature(associated_types)]
 #![unstable]
+#![allow(unstable)]
 extern crate serialize;
 extern crate encoding;
 extern crate time;
 extern crate chrono;
 
-#[phase(plugin)]
+#[macro_use]
 extern crate lazy_static;
 
 pub use header::{

--- a/src/message.rs
+++ b/src/message.rs
@@ -12,7 +12,7 @@ use std::rand::{thread_rng, Rng};
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
 
-const BOUNDARY_LENGTH: uint = 30;
+const BOUNDARY_LENGTH: usize = 30;
 
 /// Marks the type of a multipart message
 #[derive(Eq,PartialEq,Show,Copy)]
@@ -318,9 +318,9 @@ impl MimeMessage {
         let mut state = ParseState::SeenLf;
 
         // Initialize starting positions
-        let mut pos = 0u;
-        let mut boundary_start = 0u;
-        let mut boundary_end = 0u;
+        let mut pos = 0;
+        let mut boundary_start = 0;
+        let mut boundary_end = 0;
 
         let mut parts = Vec::new();
 
@@ -342,11 +342,11 @@ impl MimeMessage {
                     }
                 },
                 (ParseState::ReadBoundary, '\r') => {
-                    let read_boundary = body_slice.slice(boundary_start + 1, pos).trim();
+                    let read_boundary = body_slice[boundary_start + 1 .. pos].trim();
                     if &read_boundary.to_string() == boundary {
                         // Boundary matches, push the part
                         // The part is from the last boundary's end to this boundary's beginning
-                        let part = body_slice.slice(boundary_end, boundary_start - 1);
+                        let part = &body_slice[boundary_end .. boundary_start - 1];
                         parts.push(part.to_string());
                         // This is our boundary, so consume boundary end
                         ParseState::BoundaryEnd
@@ -371,7 +371,7 @@ impl MimeMessage {
         }
 
         // Push in the final part of the message (what remains)
-        let final_part = body_slice.slice_from(boundary_end);
+        let final_part = &body_slice[boundary_end..];
         if final_part.trim().len() != 0 {
             parts.push(final_part.to_string());
         }

--- a/src/rfc2047.rs
+++ b/src/rfc2047.rs
@@ -44,7 +44,7 @@ pub fn decode_rfc2047(s: &str) -> Option<String> {
 pub fn decode_q_encoding(s: &str) -> Result<Vec<u8>, String> {
     let mut result = Vec::new();
 
-    let mut pos = 0u;
+    let mut pos = 0;
 
     while pos < s.len() {
         let c = s.char_range_at(pos);
@@ -52,14 +52,14 @@ pub fn decode_q_encoding(s: &str) -> Result<Vec<u8>, String> {
             '=' => {
                 let mut inner_pos = c.next;
                 let mut hex_string = String::new();
-                for _ in range(0u, 2) {
+                for _ in range(0, 2) {
                     let hex_digit_char = s.char_range_at(inner_pos);
                     hex_string.push(hex_digit_char.ch);
                     inner_pos = hex_digit_char.next;
                 }
                 // = followed by a newline means a continuation
                 if hex_string.as_slice() != "\r\n" {
-                    match from_str_radix(hex_string.as_slice(), 16u) {
+                    match from_str_radix(hex_string.as_slice(), 16) {
                         Some(char_val) => { result.push(char_val) },
                         None => { return Err(format!("'{}' is not a hex number", hex_string)) },
                     }

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -4,7 +4,7 @@ use super::header::{Header, HeaderMap};
 use super::rfc2047::decode_rfc2047;
 
 #[stable]
-pub const MIME_LINE_LENGTH: uint = 78u;
+pub const MIME_LINE_LENGTH: usize = 78;
 
 trait Rfc5322Character {
     /// Is considered a special character by RFC 5322 Section 3.2.3
@@ -55,8 +55,8 @@ impl Rfc5322Character for char {
 #[unstable]
 pub struct Rfc5322Parser<'s> {
     s: &'s str,
-    pos: uint,
-    pos_stack: Vec<uint>,
+    pos: usize,
+    pos_stack: Vec<usize>,
 }
 
 impl<'s> Rfc5322Parser<'s> {
@@ -65,7 +65,7 @@ impl<'s> Rfc5322Parser<'s> {
     pub fn new(source: &'s str) -> Rfc5322Parser<'s> {
         Rfc5322Parser {
             s: source,
-            pos: 0u,
+            pos: 0,
             pos_stack: Vec::new(),
         }
     }
@@ -370,7 +370,9 @@ impl<'s> Rfc5322Parser<'s> {
     /// Returns the string of characters that returned true for the test function.
     #[inline]
     #[unstable]
-    pub fn consume_while(&mut self, test: |char| -> bool) -> String {
+    pub fn consume_while<F>(&mut self, test: F) -> String
+        where F: Fn(char) -> bool
+    {
         let start_pos = self.pos;
         while !self.eof() && test(self.peek()) {
             self.consume_char();
@@ -423,10 +425,10 @@ impl Rfc5322Builder {
 
     #[experimental]
     pub fn emit_folded(&mut self, s: &str) {
-       let mut pos = 0u;
-       let mut cur_len = 0u;
-       let mut last_space = 0u;
-       let mut last_cut = 0u;
+       let mut pos = 0;
+       let mut cur_len = 0;
+       let mut last_space = 0;
+       let mut last_cut = 0;
 
        while pos < s.len() {
            let c_range = s.char_range_at(pos);


### PR DESCRIPTION
Changes include

 - Move Show implementation for address-like things to String; derive(Show)
 - Switch to slice[a..b] syntax
 - uint -> usize
 - 5322parser.consume_while now takes Fn(char) -> bool, not a closure
 - Bumped version and updated dependencies