### PR TITLE
make test feature used only in testing as per

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(test)]
+#![cfg_attr(test, feature(test))]
 
 extern crate rustc_serialize;
 extern crate encoding;


### PR DESCRIPTION
https://www.reddit.com/r/rust/comments/2ysbaz/unstable_tests/cpcgs8a

This should make the crate usable in stable rust, at least it compiles now on rust stable :)