### PR TITLE
Remove panics

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -222,7 +222,7 @@ impl<'s> AddressParser<'s> {
         self.p.consume_char();
 
         let addr = try!(self.parse_addr_spec());
-        if self.p.consume_char() != '>' {
+        if self.p.consume_char() != Some('>') {
             // Fail because we should have a closing RANGLE here (to match the opening one)
             Err(ParsingError::new("Missing '>' at end while parsing address header.".to_string()))
         } else {

--- a/src/rfc2045.rs
+++ b/src/rfc2045.rs
@@ -45,11 +45,11 @@ impl<'s> Rfc2045Parser<'s> {
         let mut params = HashMap::new();
         while !self.parser.eof() {
             // Eat the ; and any whitespace
-            assert_eq!(self.parser.consume_char(), ';');
+            assert_eq!(self.parser.consume_char(), Some(';'));
             self.parser.consume_linear_whitespace();
 
             let attribute = self.consume_token();
-            assert_eq!(self.parser.consume_char(), '=');
+            assert_eq!(self.parser.consume_char(), Some('='));
             // Value can be token or quoted-string
             let value = if self.parser.peek() == '"' {
                 self.parser.consume_quoted_string()

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -341,7 +341,6 @@ impl<'s> Rfc5322Parser<'s> {
     /// [unstable]
     pub fn consume_char(&mut self) -> Option<char> {
         if self.eof() {
-            // TODO: Consider making this return an Option<char>
             return None
         }
         let c = self.peek();
@@ -453,7 +452,7 @@ pub struct Rfc5322Builder {
 }
 
 impl Rfc5322Builder {
-    /// Make a new builder, with an empty string
+    /// Make a new parser, with an empty string
     pub fn new() -> Rfc5322Builder {
         Rfc5322Builder {
             result: "".to_string(),
@@ -514,20 +513,20 @@ mod tests {
 
     #[test]
     fn test_parser() {
-        let mut builder = Rfc5322Parser::new("");
-        assert!(builder.consume_message().is_some());
+        let mut parser = Rfc5322Parser::new("");
+        assert!(parser.consume_message().is_some());
 
-        let mut builder = Rfc5322Parser::new("\r\n");
-        assert!(builder.consume_message().is_some());
+        let mut parser = Rfc5322Parser::new("\r\n");
+        assert!(parser.consume_message().is_some());
 
-        let mut builder = Rfc5322Parser::new("From: Garbage@-\r\n");
-        assert!(builder.consume_message().is_some());
+        let mut parser = Rfc5322Parser::new("From: Garbage@-\r\n");
+        assert!(parser.consume_message().is_some());
 
-        let mut builder = Rfc5322Parser::new("From: Garbage@");
-        assert!(builder.consume_message().is_some());
+        let mut parser = Rfc5322Parser::new("From: Garbage@");
+        assert!(parser.consume_message().is_some());
 
-        let mut builder = Rfc5322Parser::new("From: Garnage@-");
-        assert!(builder.consume_message().is_some());
+        let mut parser = Rfc5322Parser::new("From: Garnage@-");
+        assert!(parser.consume_message().is_some());
     }
 
     #[test]

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -452,7 +452,7 @@ pub struct Rfc5322Builder {
 }
 
 impl Rfc5322Builder {
-    /// Make a new parser, with an empty string
+    /// Make a new builder, with an empty string
     pub fn new() -> Rfc5322Builder {
         Rfc5322Builder {
             result: "".to_string(),

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -60,7 +60,7 @@ pub struct Rfc5322Parser<'s> {
 }
 
 impl<'s> Rfc5322Parser<'s> {
-    /// Make a new parser, initialized with the given string. 
+    /// Make a new parser, initialized with the given string.
     /// [unstable]
     pub fn new(source: &'s str) -> Rfc5322Parser<'s> {
         Rfc5322Parser {
@@ -181,7 +181,7 @@ impl<'s> Rfc5322Parser<'s> {
         let current_position = self.pos;
         let is_fws = if !self.eof() && self.consume_linebreak() {
             match self.consume_char() {
-                ' ' | '\t' => true,
+                Some(' ') | Some('\t') => true,
                 _ => false,
             }
         } else {
@@ -292,9 +292,15 @@ impl<'s> Rfc5322Parser<'s> {
                     },
                     _ => {
                         // Any old character gets pushed in
-                        quoted_string.push(self.consume_char());
-                        // Clear any escape character state we have
-                        inside_escape = false;
+                        if let Some(c) = self.consume_char() {
+                            quoted_string.push(c);
+                            // Clear any escape character state we have
+                            inside_escape = false;
+                        }
+                        // TODO: Should this return a Result<> instead of an Option<>?
+                        else {
+                            return None;
+                        }
                     },
                 }
             }
@@ -332,14 +338,14 @@ impl<'s> Rfc5322Parser<'s> {
     /// Consume a single character from the input.
     #[inline]
     /// [unstable]
-    pub fn consume_char(&mut self) -> char {
-        if self.eof() { 
+    pub fn consume_char(&mut self) -> Option<char> {
+        if self.eof() {
             // TODO: Consider making this return an Option<char>
-            panic!("Consuming beyond end of input");
+            return None
         }
         let c = self.peek();
         self.pos += c.len_utf8();
-        c
+        Some(c)
     }
 
     // Consume a linebreak: \r\n, \r or \n
@@ -352,14 +358,14 @@ impl<'s> Rfc5322Parser<'s> {
         let start_pos = self.pos;
 
         match self.consume_char() {
-            '\r' => {
+            Some('\r') => {
                 // Try to consume a single \n following the \r
                 if !self.eof() && self.peek() == '\n' {
                     self.consume_char();
                 }
                 true
             },
-            '\n' => true,
+            Some('\n') => true,
             _ => { self.pos = start_pos; false }
         }
     }
@@ -503,6 +509,24 @@ mod tests {
         input: &'s str,
         output: &'s str,
         name: &'s str,
+    }
+
+    #[test]
+    fn test_parser() {
+        let mut builder = Rfc5322Parser::new("");
+        assert!(builder.consume_message().is_some());
+
+        let mut builder = Rfc5322Parser::new("\r\n");
+        assert!(builder.consume_message().is_some());
+
+        let mut builder = Rfc5322Parser::new("From: Garbage@-\r\n");
+        assert!(builder.consume_message().is_some());
+
+        let mut builder = Rfc5322Parser::new("From: Garbage@");
+        assert!(builder.consume_message().is_some());
+
+        let mut builder = Rfc5322Parser::new("From: Garnage@-");
+        assert!(builder.consume_message().is_some());
     }
 
     #[test]

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -144,7 +144,8 @@ impl<'s> Rfc5322Parser<'s> {
             self.consume_linear_whitespace();
             let field_value = self.consume_unstructured();
 
-            assert!(self.consume_linebreak());
+            // don't just panic!()
+            if self.consume_linebreak() == false { return None };
 
             Some(Header::new(field_name, field_value))
         }


### PR DESCRIPTION
Hi,

my program used MimeMessage::parse() which returns a ParseResult.
But it paniced on certain garbage strings, which i would absolutely want to avoid (mails are usually externally delivered into the mail parser, and shouldn't just crash the program!).
Could you please check if this is good for you?

Also, did you consider rust-peg as parser generator? I've had very good experiences with it and some RFC based parsing, because you can take the RFC syntax notation and derive the PEG syntax easily.. Just a hint :)

