### PR TITLE
Make ParserResult publicly usable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub mod rfc2047;
 pub mod rfc2045;
 pub mod rfc822;
 pub mod mimeheaders;
+pub mod results;
 mod header;
 mod address;
 mod message;
-pub mod results;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,4 +31,4 @@ pub mod mimeheaders;
 mod header;
 mod address;
 mod message;
-mod results;
+pub mod results;


### PR DESCRIPTION
One can't use ParseResult, because it's not public.