### PR TITLE
fix impl ToHeader for MimeContentTypeHeader

### DIFF
--- a/src/mimeheaders.rs
+++ b/src/mimeheaders.rs
@@ -45,7 +45,7 @@ impl ToHeader for MimeContentTypeHeader {
         let (mime_major, mime_minor) = value.content_type;
         let mut result = format!("{}/{}", mime_major, mime_minor);
         for (key, val) in value.params.iter() {
-            result = format!("{} {}={};", result, key, val);
+            result = format!("{}; {}={}", result, key, val);
         }
         Ok(result)
     }


### PR DESCRIPTION
Prior code was emitting like this, with missing semicolon before the first parameter, and excess semicolon at the end:

```Content-Type: multipart/alternate boundary=ywhVrPSWsKaqHhGyVjakP2KZ3xYkmF;```