### PR TITLE
MimeMessage::as_string_without_headers()

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -205,6 +205,27 @@ impl MimeMessage {
         builder.result().clone()
     }
 
+    pub fn as_string_without_headers(&self) -> String {
+        let mut builder = Rfc5322Builder::new();
+
+        builder.emit_raw(&format!("{}\r\n", self.body)[..]);
+
+        if self.children.len() > 0 {
+
+            for part in self.children.iter() {
+                builder.emit_raw(
+                    &format!("--{}\r\n{}\r\n",
+                            self.boundary,
+                            part.as_string())[..]
+                );
+            }
+
+            builder.emit_raw(&format!("--{}--\r\n", self.boundary)[..]);
+        }
+
+        builder.result().clone()
+    }
+
     /// Decode the body of this message, as a series of bytes
     pub fn decoded_body_bytes(&self) -> Option<Vec<u8>> {
         let transfer_encoding: MimeContentTransferEncoding =

--- a/src/message.rs
+++ b/src/message.rs
@@ -186,28 +186,18 @@ impl MimeMessage {
             builder.emit_folded(&header.to_string()[..]);
             builder.emit_raw("\r\n");
         }
+        builder.emit_raw("\r\n");
 
-        builder.emit_raw(&format!("\r\n{}\r\n", self.body)[..]);
-
-        if self.children.len() > 0 {
-
-            for part in self.children.iter() {
-                builder.emit_raw(
-                    &format!("--{}\r\n{}\r\n",
-                            self.boundary,
-                            part.as_string())[..]
-                );
-            }
-
-            builder.emit_raw(&format!("--{}--\r\n", self.boundary)[..]);
-        }
-
-        builder.result().clone()
+        self.as_string_without_headers_internal(builder)
     }
 
     pub fn as_string_without_headers(&self) -> String {
-        let mut builder = Rfc5322Builder::new();
+        let builder = Rfc5322Builder::new();
 
+        self.as_string_without_headers_internal(builder)
+    }
+
+    fn as_string_without_headers_internal(&self, mut builder: Rfc5322Builder) -> String {
         builder.emit_raw(&format!("{}\r\n", self.body)[..]);
 
         if self.children.len() > 0 {


### PR DESCRIPTION
To send a Mime email, the headers often need to be added to the emailer system separately from the body part.  This function allows generation of the body part with all it's children, but without the headers.
