### PR TITLE
switch from rustc-serialize to rust-base64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 encoding = "^0.2.0"
 chrono = "^0.3.0"
 lazy_static = "^0.2.0"
-rustc-serialize = "^0.3.0"
+base64 = "~0.5.0"
 rand = "^0.3.0"
 time = "^0.1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(all(feature = "nightly", test), feature(test))]
 
-extern crate rustc_serialize;
+extern crate base64;
 extern crate encoding;
 extern crate time;
 extern crate chrono;

--- a/src/mimeheaders.rs
+++ b/src/mimeheaders.rs
@@ -8,7 +8,7 @@ use super::results::{ParsingResult,ParsingError};
 
 use std::ascii::AsciiExt;
 use std::collections::HashMap;
-use rustc_serialize::base64::FromBase64;
+use base64;
 
 /// Content-Type string, major/minor as the first and second elements
 /// respectively.
@@ -76,7 +76,7 @@ impl MimeContentTransferEncoding {
         match *self {
             MimeContentTransferEncoding::Identity => Some(input.clone().into_bytes()),
             MimeContentTransferEncoding::QuotedPrintable => decode_q_encoding(&input[..]).ok(),
-            MimeContentTransferEncoding::Base64 => input[..].from_base64().ok(),
+            MimeContentTransferEncoding::Base64 => base64::decode_config(&input[..], base64::MIME).ok(),
         }
     }
 }

--- a/src/rfc2047.rs
+++ b/src/rfc2047.rs
@@ -1,7 +1,7 @@
 //! Module for decoding RFC 2047 strings
 // use for to_ascii_lowercase
 use std::ascii::AsciiExt;
-use rustc_serialize::base64::FromBase64;
+use base64::decode;
 
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
@@ -72,7 +72,7 @@ pub fn decode_q_encoding(s: &str) -> Result<Vec<u8>, String> {
 }
 
 fn decode_base64_encoding(s: &str) -> Result<Vec<u8>, String> {
-    match s.from_base64() {
+    match decode(s) {
         Ok(bytes) => Ok(bytes),
         Err(_) => Err("Failed to base64 decode".to_string()),
     }


### PR DESCRIPTION
Since the [rustc-serialize crate is being deprecated](https://users.rust-lang.org/t/deprecation-of-rustc-serialize/10485?u=dtolnay) it seems like a good idea to replace it's use. Since it is solely used here for base64, this change migrates to the use of https://crates.io/crates/base64, which provides everything needed.