### PR TITLE
Update the chrono and base64 crates versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email"
-version = "0.0.17"
+version = "0.0.18"
 authors = ["Nicholas Hollett <niax@niax.co.uk>"]
 description = "Implementation of RFC 5322 email messages"
 repository = "https://github.com/niax/rust-email"
@@ -10,9 +10,9 @@ build = "build.rs"
 
 [dependencies]
 encoding = "^0.2.0"
-chrono = "^0.3.0"
+chrono = "^0.4.0"
 lazy_static = "^0.2.0"
-base64 = "^0.5.0"
+base64 = "^0.6.0"
 rand = "^0.3.0"
 time = "^0.1.0"
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use chrono::{
     DateTime,
     FixedOffset,
-    UTC,
+    Utc,
 };
 
 use super::rfc2047::decode_rfc2047;
@@ -130,10 +130,10 @@ impl FromHeader for DateTime<FixedOffset> {
     }
 }
 
-impl FromHeader for DateTime<UTC> {
-    fn from_header(value: String) -> ParsingResult<DateTime<UTC>> {
+impl FromHeader for DateTime<Utc> {
+    fn from_header(value: String) -> ParsingResult<DateTime<Utc>> {
         let dt: ParsingResult<DateTime<FixedOffset>> = FromHeader::from_header(value);
-        dt.map(|i| i.with_timezone(&UTC))
+        dt.map(|i| i.with_timezone(&Utc))
     }
 }
 
@@ -310,7 +310,7 @@ mod tests {
     use chrono::{
         DateTime,
         FixedOffset,
-        UTC,
+        Utc,
     };
     use chrono::offset::TimeZone;
 
@@ -381,8 +381,8 @@ mod tests {
     #[test]
     fn test_datetime_utc_get_value() {
         let header = Header::new("Date".to_string(), "Wed, 17 Dec 2014 09:35:07 +0100".to_string());
-        let dt_value = header.get_value::<DateTime<UTC>>().unwrap();
-        assert_eq!(dt_value, UTC.ymd(2014, 12, 17).and_hms(8, 35, 7));
+        let dt_value = header.get_value::<DateTime<Utc>>().unwrap();
+        assert_eq!(dt_value, Utc.ymd(2014, 12, 17).and_hms(8, 35, 7));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate base64;
 extern crate encoding;
-extern crate time;
 extern crate chrono;
 extern crate rand;
 

--- a/src/rfc822.rs
+++ b/src/rfc822.rs
@@ -137,12 +137,12 @@ impl<'s> Rfc822DateParser<'s> {
     /// extern crate email;
     ///
     /// use email::rfc822::Rfc822DateParser;
-    /// use chrono::UTC;
+    /// use chrono::Utc;
     ///
     /// fn main() {
     ///     let mut p = Rfc822DateParser::new("Thu, 18 Dec 2014 21:07:22 +0100");
     ///     let d = p.consume_datetime().unwrap();
-    ///     let as_utc = d.with_timezone(&UTC);
+    ///     let as_utc = d.with_timezone(&Utc);
     ///
     ///     assert_eq!(d, as_utc);
     /// }


### PR DESCRIPTION
That prevents multiple versions of these crates to be pulled when using rust-email with other crates.