### PR TITLE
Support for parsing messages with Unix line endings

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -481,19 +481,19 @@ mod tests {
             ParseTest {
                 input: "From: joe@example.org\n\
                         To: john@example.org\n\
-                        Content-Type: multipart/alternative; boundary=\"=-foo\"\n\
+                        Content-Type: multipart/alternative; boundary=\"foo\"\n\
                         \n\
                         \n\
                         Parent\n\
-                        --=-foo\n\
+                        --foo\n\
                         Hello!\n\
-                        --=-foo\n\
+                        --foo\n\
                         Other\n",
                 output: Some(MessageTestResult {
                     headers: vec![
                         ("From", "joe@example.org"),
                         ("To", "john@example.org"),
-                        ("Content-Type", "multipart/alternative; boundary=\"=-foo\""),
+                        ("Content-Type", "multipart/alternative; boundary=\"foo\""),
                     ],
                     body: "\nParent\n",
                     children: vec![

--- a/src/message.rs
+++ b/src/message.rs
@@ -355,7 +355,9 @@ impl MimeMessage {
                     ParseState::ReadBoundary
                 },
                 (ParseState::SeenLf, '-') => ParseState::SeenDash,
-                (ParseState::SeenCr, '\n') | (ParseState::Normal, '\n') => ParseState::SeenLf,
+                (ParseState::SeenLf, '\n') => ParseState::SeenLf,
+                (ParseState::Normal, '\n') => ParseState::SeenLf,
+                (ParseState::SeenCr, '\n') => ParseState::SeenLf,
                 (ParseState::Normal, '\r') => ParseState::SeenCr,
                 (ParseState::Normal, _) => ParseState::Normal,
                 (_, _) => ParseState::Normal,
@@ -479,20 +481,21 @@ mod tests {
             ParseTest {
                 input: "From: joe@example.org\n\
                         To: john@example.org\n\
-                        Content-Type: multipart/alternative; boundary=foo\n\
+                        Content-Type: multipart/alternative; boundary=\"=-foo\"\n\
+                        \n\
                         \n\
                         Parent\n\
-                        --foo\n\
+                        --=-foo\n\
                         Hello!\n\
-                        --foo\n\
+                        --=-foo\n\
                         Other\n",
                 output: Some(MessageTestResult {
                     headers: vec![
                         ("From", "joe@example.org"),
                         ("To", "john@example.org"),
-                        ("Content-Type", "multipart/alternative; boundary=foo"),
+                        ("Content-Type", "multipart/alternative; boundary=\"=-foo\""),
                     ],
-                    body: "Parent\n",
+                    body: "\nParent\n",
                     children: vec![
                         MessageTestResult {
                             headers: vec![ ],

--- a/src/message.rs
+++ b/src/message.rs
@@ -350,15 +350,13 @@ impl MimeMessage {
                     }
                 },
                 (ParseState::ReadBoundary, _) => ParseState::ReadBoundary,
+                (_, '\n') => ParseState::SeenLf,
+                (_, '\r') => ParseState::SeenCr,
                 (ParseState::SeenDash, '-') => {
                     boundary_start = pos;
                     ParseState::ReadBoundary
                 },
                 (ParseState::SeenLf, '-') => ParseState::SeenDash,
-                (ParseState::SeenLf, '\n') => ParseState::SeenLf,
-                (ParseState::Normal, '\n') => ParseState::SeenLf,
-                (ParseState::SeenCr, '\n') => ParseState::SeenLf,
-                (ParseState::Normal, '\r') => ParseState::SeenCr,
                 (ParseState::Normal, _) => ParseState::Normal,
                 (_, _) => ParseState::Normal,
             };


### PR DESCRIPTION
Hello,

I wanted Unix line ending support for a personal project, and I was able to get parsing working with just a few modifications.  I also added a couple Unix line ending specific tests.

My changes were only to methods related to parsing - I didn't make any changes to support Unix line endings in message output from methods like `MimeMessage::as_string()`

I also didn't see a need to make any documentation edits - there's a few methods in `rfc5322.rs` that mentioned CRLF specifically, but they already supported Unix line endings.