### PR TITLE
Encode header values according to RFC 2047

### DIFF
--- a/src/header.rs
+++ b/src/header.rs
@@ -462,14 +462,24 @@ mod tests {
     fn test_header_with_email_address_only_encodes_name() {
         use rfc2047::encode_rfc2047;
 
-        let first_name = "Renée";
-        let last_name = "Sørensen";
-        let email = "renee.sorensen@foo.bar";
-        let value = format!("{} {} <{}>", first_name, last_name, email);
+        let value = "Renée Sørensen <renee.sorensen@foo.bar>";
         let header = Header::new_with_value("From".to_string(), value).unwrap();
         assert_eq!(
             format!("{}", header),
-            format!("From: {} {} <{}>", encode_rfc2047(&first_name), encode_rfc2047(&last_name), email)
+            format!("From: {} {} <{}>", encode_rfc2047("Renée"), encode_rfc2047("Sørensen"), "renee.sorensen@foo.bar")
         );
+    }
+
+    #[test]
+    fn test_header_decoding_reverses_encoding() {
+        let test_values = [
+            "汤唯 <a@b.c>",
+            "André <a@b.c>",
+            "Iñigo Montoya <a@b.c>",
+        ];
+        for value in &test_values {
+            let header = Header::new_with_value("To".to_string(), value.to_string()).unwrap();
+            assert_eq!(header.get_value::<String>().unwrap(), value.to_string());
+        }
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -195,7 +195,9 @@ impl Header {
 
 impl fmt::Display for Header {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{}: {}", self.name, self.value)
+        use rfc2047::encode_rfc2047;
+
+        write!(fmt, "{}: {}", self.name, encode_rfc2047(&self.value))
     }
 }
 
@@ -431,5 +433,17 @@ mod tests {
         }
         // And that there is the right number of them
         assert_eq!(count, expected_headers.len());
+    }
+
+    #[test]
+    fn test_header_encodes_value_as_rfc2047() {
+        use rfc2047::encode_rfc2047;
+
+        let value = "Hällö".to_string();
+        let header = Header::new_with_value("Subject".to_string(), value.clone()).unwrap();
+        assert_eq!(
+            format!("{}", header)[9..],
+            encode_rfc2047(&value)
+        );
     }
 }

--- a/src/rfc2047.rs
+++ b/src/rfc2047.rs
@@ -1,7 +1,7 @@
 //! Module for decoding RFC 2047 strings
 // use for to_ascii_lowercase
 use std::ascii::AsciiExt;
-use base64::decode;
+use base64::{self, decode};
 
 use encoding::label::encoding_from_whatwg_label;
 use encoding::DecoderTrap;
@@ -36,6 +36,21 @@ pub fn decode_rfc2047(s: &str) -> Option<String> {
             }
             _ => None,
         }
+    }
+}
+
+/// Encode a UTF-8 Rust string according to RFC 2047, if need be.
+///
+/// Currently, this only uses "B" encoding, when pure ASCII cannot represent the
+/// string accurately.
+pub fn encode_rfc2047(text: &str) -> String {
+    if text.is_ascii() {
+        format!("{}", text)
+    } else {
+        format!(
+            "=?utf-8?B?{}?=",
+            base64::encode_config(text.as_bytes(), base64::MIME)
+        )
     }
 }
 
@@ -103,11 +118,11 @@ mod tests {
     fn test_decode() {
         let tests = [
             DecodeTest {
-                input: "=?ISO-8859-1?Q?Test=20text?=", 
+                input: "=?ISO-8859-1?Q?Test=20text?=",
                 output: "Test text"
             },
             DecodeTest {
-                input: "=?ISO-8859-1?b?VGVzdCB0ZXh0?=", 
+                input: "=?ISO-8859-1?b?VGVzdCB0ZXh0?=",
                 output: "Test text"
             },
             DecodeTest {
@@ -136,7 +151,7 @@ mod tests {
             },
         ];
 
-        for t in tests.iter() { 
+        for t in tests.iter() {
             assert_eq!(decode_q_encoding(t.input).unwrap(), t.output.to_vec());
         }
     }
@@ -156,5 +171,17 @@ mod tests {
             println!("{}", t);
             assert!(decode_rfc2047(*t).is_none());
         }
+    }
+
+    #[test]
+    fn test_encode_preserves_ascii_string() {
+        let plain_ascii = "uiae 282!";
+        assert_eq!(encode_rfc2047(plain_ascii), plain_ascii);
+    }
+
+    #[test]
+    fn test_encode_uses_base64_for_non_ascii_string() {
+        let umlauty = "Überräschùng!";
+        assert_eq!(&encode_rfc2047(umlauty)[..10], "=?utf-8?B?");
     }
 }

--- a/src/rfc2047.rs
+++ b/src/rfc2047.rs
@@ -184,4 +184,13 @@ mod tests {
         let umlauty = "Überräschùng!";
         assert_eq!(&encode_rfc2047(umlauty)[..10], "=?utf-8?B?");
     }
+
+    #[test]
+    fn test_decode_is_inverse_of_encode() {
+        let umlauty = "Hällöö";
+        assert_eq!(
+            decode_rfc2047(&encode_rfc2047(umlauty)).unwrap(),
+            umlauty
+        );
+    }
 }


### PR DESCRIPTION
I started this to address #3. This does not do much yet, it only checks whether the value is ASCII and, if not, uses base64 encoding.

It's better than nothing still and I'd be willing to do the rest of #3, but wanted to get some feedback, as the issue is quite old and I have not worked on this crate before.

Is changing the impl of `Display` for `Header` sufficient to make this work?