### PR TITLE
"user@ email address should fail parsing, not panic

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -313,6 +313,13 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_address_parsing() {
+	for a in vec!["<a@example.com", "a@"].iter() {
+            AddressParser::new(a).parse_mailbox().expect_err("parse failure");
+        }
+    }
+
+    #[test]
     fn test_address_group_to_string() {
         let addr = Address::new_group("undisclosed recipients".to_string(), vec![]);
         assert_eq!(addr.to_string(), "undisclosed recipients: ;".to_string());

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -321,7 +321,7 @@ impl<'s> Rfc5322Parser<'s> {
     /// atext character.
     /// [unstable]
     pub fn consume_atom(&mut self, allow_dot: bool) -> Option<String> {
-        if !self.peek().is_atext() {
+        if self.eof() || !self.peek().is_atext() {
             None
         } else {
             Some(self.consume_while(|c| {


### PR DESCRIPTION
I happened across this issue where "user@" panics the parser instead of returning None.
Obviously the test added here is a long way off complete, but at least it catches this case.