### PR TITLE
don't crash with a trailing semi colon

### DIFF
--- a/src/mimeheaders.rs
+++ b/src/mimeheaders.rs
@@ -145,6 +145,16 @@ mod tests {
                     ],
                 }),
             },
+            ContentTypeParseTest {
+                input: "text/plain; charset=\"windows-1251\";",
+                result: Some(ContentTypeParseTestResult {
+                    major_type: "text",
+                    minor_type: "plain",
+                    params: vec![
+                        ("charset", "windows-1251"),
+                    ],
+                }),
+            }
         ];
 
         for test in tests.into_iter() {

--- a/src/rfc2045.rs
+++ b/src/rfc2045.rs
@@ -46,6 +46,11 @@ impl<'s> Rfc2045Parser<'s> {
         while !self.parser.eof() {
             // Eat the ; and any whitespace
             assert_eq!(self.parser.consume_char(), Some(';'));
+
+            // RFC ignorant mail systems may append a ';' without a parameter after.
+            // This violates the RFC but does happen, so deal with it.
+            if self.parser.eof() { break; }
+
             self.parser.consume_linear_whitespace();
 
             let attribute = self.consume_token();


### PR DESCRIPTION
Avoid crashing if an ignorant mail system has appended a semi-colon to the Content-Type line.