### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,15 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-encoding = "^0.2.0"
-chrono = "^0.4.0"
-lazy_static = "1.0"
-base64 = "0.9"
-rand = "0.6"
-time = "^0.1.0"
+encoding = "0.2.33"
+chrono = "0.4.9"
+lazy_static = "1.4.0"
+base64 = "0.11.0"
+rand = "0.7.2"
+time = "0.1.42"
 
 [features]
 nightly = []
 
 [build-dependencies]
-version_check = "0.1"
+version_check = "0.9.1"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,9 @@
 extern crate version_check;
 
+use version_check::Channel;
+
 fn main() {
-    if version_check::is_nightly().unwrap_or(false) {
+    if Channel::read().as_ref().map(Channel::is_nightly).unwrap_or(false) {
         println!("cargo:rustc-cfg=feature=\"nightly\"");
     }
 }


### PR DESCRIPTION
Updates all crate dependencies to the latest version, as well as dev-dependencies.

Two code changes were necessary:
1. *build.rs*: Due to a new API in version_check, the if condition had to be updated.
2. *src/mimeheader.rs*: Since the `base64::MIME` config was removed with version 0.10.0, I had to roll my own exclude-non-base64-bytes logic, in order to follow RFC 2045. Thankfully this was trivial.

No API breaking changes present.