### PR TITLE
replace encoding with encoding_rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-encoding = "0.2.33"
+encoding_rs = "0.8"
 chrono = "0.4.9"
 lazy_static = "1.4.0"
-base64 = "0.11.0"
+base64 = "0.12.0"
 rand = "0.7.2"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate base64;
 extern crate chrono;
-extern crate encoding;
+extern crate encoding_rs as encoding;
 extern crate rand;
 
 #[macro_use]

--- a/src/rfc2047.rs
+++ b/src/rfc2047.rs
@@ -2,8 +2,7 @@
 // use for to_ascii_lowercase
 use base64::decode;
 
-use encoding::label::encoding_from_whatwg_label;
-use encoding::DecoderTrap;
+use encoding::Encoding;
 
 /// Decode an RFC 2047 string (`s`) into a Rust String.
 ///
@@ -27,10 +26,13 @@ pub fn decode_rfc2047(s: &str) -> Option<String> {
 
         // XXX: Relies on WHATWG labels, rather than MIME labels for
         // charset. Consider adding mapping upstream.
-        let decoder = encoding_from_whatwg_label(&charset[..]);
+        let decoder = Encoding::for_label(charset[..].as_bytes());
 
         match (bytes, decoder) {
-            (Ok(b), Some(d)) => d.decode(&b, DecoderTrap::Replace).ok(),
+            (Ok(b), Some(d)) => {
+                let (x, ..) = d.decode(&b);
+                Some(x.into_owned())
+            },
             _ => None,
         }
     }


### PR DESCRIPTION
The `encoding` crate has been lost for maintenance for more than four years, and this PR replaces it with `encoding_rs` made by mozilla.