### PR TITLE
Comply to RFC 5322

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "email"
-version = "0.0.21"
+version = "0.1.0"
 authors = ["Nicholas Hollett <niax@niax.co.uk>"]
 description = "Implementation of RFC 5322 email messages"
 repository = "https://github.com/niax/rust-email"

--- a/src/header.rs
+++ b/src/header.rs
@@ -467,10 +467,16 @@ mod tests {
     }
 }
 
+/// The behavior of the parser when unfolding headers.  
+///   
+/// The default is UnfoldingStrategy::Clean for compatibility reasons with previous versions of the crate, but you should use UnfoldingStrategy::RfcCompliant.
 #[derive(Debug, Clone, Copy)]
 pub enum UnfoldingStrategy {
+    /// Keeps every CRLF and whitespace (No unfolding)
     None,
+    /// Only remove CRLF and keeps whitespaces as defined in the RFC.
     RfcCompliant,
+    /// Remove every CRLF and whitespace. Default for compatibility reasons.
     Clean,
 }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -466,3 +466,28 @@ mod tests {
         assert_eq!(count, expected_headers.len());
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum UnfoldingStrategy {
+    None,
+    RfcCompliant,
+    Clean,
+}
+
+impl UnfoldingStrategy {
+    pub(crate) fn delete_wsp(&self) -> bool {
+        match self {
+            UnfoldingStrategy::None => false,
+            UnfoldingStrategy::RfcCompliant => false,
+            UnfoldingStrategy::Clean => true,
+        }
+    }
+
+    pub(crate) fn delete_crlf(&self) -> bool {
+        match self {
+            UnfoldingStrategy::None => false,
+            UnfoldingStrategy::RfcCompliant => true,
+            UnfoldingStrategy::Clean => true,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ extern crate rand;
 extern crate lazy_static;
 
 pub use crate::address::{Address, Mailbox};
-pub use crate::header::{FromHeader, Header, HeaderIter, HeaderMap, ToFoldedHeader, ToHeader};
+pub use crate::header::{FromHeader, Header, HeaderIter, HeaderMap, ToFoldedHeader, ToHeader, UnfoldingStrategy};
 pub use crate::message::{MimeMessage, MimeMultipartType};
 
 mod address;

--- a/src/rfc5322.rs
+++ b/src/rfc5322.rs
@@ -62,7 +62,10 @@ pub struct Rfc5322Parser<'s> {
 }
 
 impl<'s> Rfc5322Parser<'s> {
-    /// Make a new parser, initialized with the given string.
+    /// Make a new parser, initialized with the given string.  
+    ///   
+    /// This will use a non RFC compliant unfolding strategy on headers.
+    /// Consider using the `new_with_unfolding_strategy` method to specify the behavior of the parser when unfolding headers.
     /// [unstable]
     pub fn new(source: &'s str) -> Rfc5322Parser<'s> {
         Rfc5322Parser {


### PR DESCRIPTION
According to RFC 5322, "unfolding is accomplished by simply removing any CRLF that is immediately followed by WSP" (https://tools.ietf.org/html/rfc5322#section-2.2.3).
However, the rust email crate was removing not only the CRLF but also any following WSP!
This behavior may be desired, but is not RFC compliant.
That's why I added a configuration enum called `UnfoldingStrategy`.
You can use the UnfoldingStrategy enum to specify the behavior of the parser when unfolding headers.
To use the RFC compliant behavior, you can use `UnfoldingStrategy::RfcCompliant`.
To build a Parser using a custom unfolding strategy, use the `new_with_unfolding_strategy` method instead of `new`.
The `new` method will build a parser with the same behavior as before (UnfoldingStrategy::Clean), to avoid huge breaking changes.

Some small breaking changes have been introduced.