### PR TITLE
Remove default-features from chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 
 [dependencies]
 encoding_rs = "0.8"
-chrono = "0.4.9"
+chrono = { version = "0.4.9", default-features = false }
 lazy_static = "1.4.0"
 base64 = "0.12.0"
 rand = "0.7.2"


### PR DESCRIPTION
Many of the features of chrono aren't used in this library. This simplifies the build tree.